### PR TITLE
Bugfix for IOC crash due to unitialized variable

### DIFF
--- a/linkamT96App/src/linkamT96.cpp
+++ b/linkamT96App/src/linkamT96.cpp
@@ -134,6 +134,9 @@ asynStatus linkamPortDriver::readOctet(asynUser *pasynUser, char *value, size_t 
 	  if (linkamProcessMessage(LinkamSDK::eLinkamFunctionMsgCode_GetControllerError, handle, &result)) {
 
       strcpy(value, LinkamSDK::ControllerErrorStrings[result.vControllerError]);
+		  setStringParam(function, value);
+		  
+		  *nActual = strlen(value) + 1;
 		  *eomReason = 0;
 
 	  } else {


### PR DESCRIPTION
*nActual is undefined when the the controller error string is read, which can cause segfaults, as the value is used as an array index in asyn code.

This bug was discovered using v3.0.19 of the SDK.